### PR TITLE
Humidity measurement data is unsigned 16-bit.

### DIFF
--- a/source/bme280.ads
+++ b/source/bme280.ads
@@ -1,4 +1,4 @@
---  SPDX-FileCopyrightText: 2023 Max Reznik <reznikmm@gmail.com>
+--  SPDX-FileCopyrightText: 2023-2024 Max Reznik <reznikmm@gmail.com>
 --
 --  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ----------------------------------------------------------------
@@ -109,7 +109,7 @@ private
    type Measurement is record
       Raw_Press : Unsigned_20;
       Raw_Temp  : Unsigned_20;
-      Raw_Hum   : Interfaces.Integer_16;
+      Raw_Hum   : Interfaces.Unsigned_16;
    end record;
 
 end BME280;

--- a/source/impl/bme280-raw.adb
+++ b/source/impl/bme280-raw.adb
@@ -84,9 +84,9 @@ package body BME280.Raw is
          + Shift_Left  (Unsigned_32 (Raw (16#FB#)), 4)
          + Shift_Right (Unsigned_32 (Raw (16#FC#)), 4));
 
-      Value.Raw_Hum := Interfaces.Integer_16
-        (Shift_Left (Unsigned_16 (Raw (16#FD#)), 8)
-         + Unsigned_16 (Raw (16#FE#)));
+      Value.Raw_Hum :=
+        Shift_Left (Unsigned_16 (Raw (16#FD#)), 8)
+        + Unsigned_16 (Raw (16#FE#));
 
       return Value;
    end Get_Measurement;


### PR DESCRIPTION
[BME280 Datasheet] 4.2.3

"Humidity is expected to be received in 16 bit format, positive, stored in a 32 bit
signed integer."